### PR TITLE
HC-175: install flask-restx v0.2.0 to address issues with werkzeug v1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,7 @@ setup(
                        'Flask-Login',
                        'Flask-Mail',
                        'Flask-Migrate',
-                       # TODO: remove installation of master branch after new release of
-                       # flask-restx includes the fix referred to here:
-                       # https://github.com/python-restx/flask-restx/issues/85
-                       #'flask-restx',
-                       'flask-restx @ git+https://git@github.com/python-restx/flask-restx',
+                       'flask-restx>=0.2.0',
                        'Flask-Script',
                        'Flask-SQLAlchemy',
                        'Flask-Testing',


### PR DESCRIPTION
End-to-end test ran successfully on NISAR dev cluster.