### PR TITLE
HC-377

### DIFF
--- a/pele/lib/client.py
+++ b/pele/lib/client.py
@@ -1,7 +1,45 @@
 from builtins import object
 import requests
 import time
+from osgeo import ogr
 
+# Utility function that returns the extent for the features in the 
+# given file (and optionally named layer), returned in the format 
+# compatible with pele/ES geospatial searches.
+#
+def getPeleExtentFromOGRFile(ogrFileName, layerName=None):
+    result = None
+    layer = None
+
+    # an exception will be thrown if Open() fails, so we
+    # won't bother checking to see if dataset is None
+    dataset = ogr.Open(ogrFileName, update=0)
+    if layerName is not None:
+        layer = dataset.GetLayerByName(layerName)
+    else:
+        # no named layer
+        if dataset.GetLayerCount() > 1:
+            print("No layer name specified for a multi-layer file, using top layer.")
+        layer = dataset.GetLayer(0)
+
+    if layer is not None:
+        extent = layer.GetExtent()
+        bottom = extent[0]
+        top = extent[1]
+        left = extent[2]
+        right = extent[3]
+
+        result = []
+        result.append([bottom, left])
+        result.append([bottom, right])
+        result.append([top, right])
+        result.append([top, left])
+        result.append([bottom, left])
+    else:
+        print("No suitable layer found.")
+
+    return result
+    
 
 class PeleRequests(object):
     def __init__(self, base_url, verify=True, auth=True):

--- a/pele/lib/client.py
+++ b/pele/lib/client.py
@@ -35,6 +35,9 @@ def getPeleExtentFromOGRFile(ogrFileName, layerName=None):
         result.append([top, right])
         result.append([top, left])
         result.append([bottom, left])
+
+        # make sure to conform to filter format
+        result = [result]
     else:
         print("No suitable layer found.")
 


### PR DESCRIPTION
From NSDS-1427 (Pele mods for Cal/Val use cases).

Used osgeo.ogr package instead of rasterio since the former supports layered files. Added optional parameter to identify named layer in the event the file contains > 1 (default is to use the first layer in file). Returns polygon in Pele/ES geospatial friendly format.