### PR TITLE
HC-367: Update to latest Pallet Project versions

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ migrate = Migrate(app, db)
 
 @app.shell_context_processor
 def make_shell_context():
-    return dict(app=app, db=db)
+    return dict(app=app, db=db, User=User)
 
 
 @app.cli.command()

--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
 import os
-import sys
-import click
 import unittest
 import coverage
-from flask_migrate import Migrate, MigrateCommand
+from flask_migrate import Migrate
 
 from pele import create_app, db
 
@@ -24,7 +22,7 @@ migrate = Migrate(app, db)
 
 @app.shell_context_processor
 def make_shell_context():
-    return dict(app=app, db=db, User=User)
+    return dict(app=app, db=db)
 
 
 @app.cli.command()

--- a/pele/__init__.py
+++ b/pele/__init__.py
@@ -130,7 +130,7 @@ def create_app(object_name):
     # /export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/scaffold.py:57:
     # UserWarning: The name 'restx_doc' is already registered for this blueprint.
     # Use 'name=' to provide a unique name. This will become an error in Flask 2.1.
-    app.register_blueprint(apidoc.apidoc, name="pele_restex_doc")
+    app.register_blueprint(apidoc.apidoc, name="pele_restx_doc")
 
     return app
 

--- a/pele/__init__.py
+++ b/pele/__init__.py
@@ -125,7 +125,12 @@ def create_app(object_name):
 
     from .controllers.api_v01 import services as api_v01
     app.register_blueprint(api_v01)
-    app.register_blueprint(apidoc.apidoc)
+    # If a unique name is not specified, the following warning is issued:
+    #
+    # /export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/scaffold.py:57:
+    # UserWarning: The name 'restx_doc' is already registered for this blueprint.
+    # Use 'name=' to provide a unique name. This will become an error in Flask 2.1.
+    app.register_blueprint(apidoc.apidoc, name="pele_restex_doc")
 
     return app
 

--- a/pele/extensions.py
+++ b/pele/extensions.py
@@ -7,7 +7,7 @@ from flask_assets import Environment
 from flask_sqlalchemy import SQLAlchemy
 from flask_httpauth import HTTPBasicAuth
 from flask_limiter import Limiter
-from flask_limiter.util import get_ipaddr
+from flask_limiter.util import get_remote_address
 from flask_mail import Mail
 
 
@@ -37,7 +37,7 @@ db = SQLAlchemy()
 auth = HTTPBasicAuth()
 
 # set up limiter
-limiter = Limiter(key_func=get_ipaddr)
+limiter = Limiter(key_func=get_remote_address)
 
 # set up mail
 mail = Mail()

--- a/pele/forms.py
+++ b/pele/forms.py
@@ -4,5 +4,5 @@ from wtforms import validators
 
 
 class LoginForm(Form):
-    username = StringField('Username', validators=[validators.required()])
+    username = StringField('Username', validators=[validators.input_required()])
     password = PasswordField('Password', validators=[validators.optional()])

--- a/pele/forms.py
+++ b/pele/forms.py
@@ -1,8 +1,8 @@
 from flask_wtf import Form
-from wtforms import TextField, PasswordField
+from wtforms import StringField, PasswordField
 from wtforms import validators
 
 
 class LoginForm(Form):
-    username = TextField('Username', validators=[validators.required()])
+    username = StringField('Username', validators=[validators.required()])
     password = PasswordField('Password', validators=[validators.optional()])

--- a/setup.py
+++ b/setup.py
@@ -8,26 +8,22 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # TODO: remove this pin on click once this celery issue is resolved:
-        # https://github.com/celery/celery/issues/6768
-        # 'click>=7.0,<8.0',  # don't think we need click here because its nto used by mozart
-        # TODO: remove these pins on flask/extensions once the celery issue above is resolved
-        'Flask>2.0.0,<3.0.0',
+        'Flask>2.0.0',
         'flask-restx>=0.5.1',
-        'Flask-Assets>=2.0,<3.0.0',
-        'Flask-Bcrypt>=0.7.1,<1.0.0',
-        'Flask-Caching>=1.10.1,<2.0.0',
-        'Flask-Cors>=3.0.10,<4.0.0',
-        'Flask-DebugToolbar>=0.11.0,<1.0.0',
-        'Flask-HTTPAuth>=4.4.0,<5.0.0',
-        'Flask-Limiter>=1.4,<2.0.0',
-        'Flask-Login>=0.5.0,<1.0.0',
-        'Flask-Mail>=0.9.1,<1.0.0',
-        'Flask-Migrate>=2.7.0,<3.0.0',  # may need to look into sdscli to update this to >=3.0.0
-        'Flask-Script>=2.0.6,<3.0.0',
-        'Flask-SQLAlchemy>=2.5.1,<3.0.0',
-        'Flask-Testing>=0.8.1,<1.0.0',
-        'Flask-WTF>=0.15.1,<1.0.0',
+        'Flask-Assets>=2.0',
+        'Flask-Bcrypt>=0.7.1',
+        'Flask-Caching>=1.10.1',
+        'Flask-Cors>=3.0.10',
+        'Flask-DebugToolbar>=0.11.0',
+        'Flask-HTTPAuth>=4.4.0',
+        'Flask-Limiter>=1.4',
+        'Flask-Login>=0.5.0',
+        'Flask-Mail>=0.9.1',
+        'Flask-Migrate>=2.7.0',  # may need to look into sdscli to update this to >=3.0.0
+        'Flask-Script>=2.0.6',
+        'Flask-SQLAlchemy>=2.5.1',
+        'Flask-Testing>=0.8.1',
+        'Flask-WTF>=0.15.1',
         'elasticsearch>=7.0.0,<7.14.0',
         'elasticsearch-dsl>=7.0.0,<7.4.0',
         'shapely>=1.5.15,<1.7.0',

--- a/setup.py
+++ b/setup.py
@@ -10,24 +10,25 @@ setup(
     install_requires=[
         # TODO: remove this pin on click once this celery issue is resolved:
         # https://github.com/celery/celery/issues/6768
-        'click>=7.0,<8.0',
+        # 'click>=7.0,<8.0',  # don't think we need click here because its nto used by mozart
         # TODO: remove these pins on flask/extensions once the celery issue above is resolved
-        'flask-restx>=0.4.0',
+        'Flask>2.0.0,<3.0.0',
+        'flask-restx>=0.5.1',
         'Flask>=1.1.2,<2.0.0',
         'Flask-Assets>=2.0,<3.0.0',
         'Flask-Bcrypt>=0.7.1,<1.0.0',
         'Flask-Caching>=1.10.1,<2.0.0',
         'Flask-Cors>=3.0.10,<4.0.0',
         'Flask-DebugToolbar>=0.11.0,<1.0.0',
-        'Flask-HTTPAuth>=4.3.0,<5.0.0',
+        'Flask-HTTPAuth>=4.4.0,<5.0.0',
         'Flask-Limiter>=1.4,<2.0.0',
         'Flask-Login>=0.5.0,<1.0.0',
         'Flask-Mail>=0.9.1,<1.0.0',
-        'Flask-Migrate>=2.7.0,<3.0.0',
+        'Flask-Migrate>=2.7.0,<3.0.0',  # may need to look into sdscli to update this to >=3.0.0
         'Flask-Script>=2.0.6,<3.0.0',
         'Flask-SQLAlchemy>=2.5.1,<3.0.0',
         'Flask-Testing>=0.8.1,<1.0.0',
-        'Flask-WTF>=0.14.3,<1.0.0',
+        'Flask-WTF>=0.15.1,<1.0.0',
         'elasticsearch>=7.0.0,<7.14.0',
         'elasticsearch-dsl>=7.0.0,<=7.4.0',
         'shapely==1.5.15',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Flask-SQLAlchemy>=2.5.1',
         'Flask-Testing>=0.8.1',
         'Flask-WTF>=0.15.1',
-        "elasticsearch>=7.0.0,<8.0.0",
+        "elasticsearch>=7.0.0,7.14.0",
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',
         'WTForms>=2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'elasticsearch-dsl>=7.0.0,<7.4.0',
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',
-        'WTForms>=2.0.0,<3.0.0',
+        'WTForms>=2.0.0',
         "aws-requests-auth==0.4.2",
         'gunicorn',
         'gevent',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Flask-SQLAlchemy>=2.5.1',
         'Flask-Testing>=0.8.1',
         'Flask-WTF>=0.15.1',
-        "elasticsearch>=7.0.0,7.14.0",
+        "elasticsearch>=7.0.0,<7.14.0",
         'elasticsearch-dsl>=7.0.0,<7.4.0',
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pele',
-    version='1.1.2',
+    version='1.1.3',
     long_description='REST API for HySDS Datasets',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Flask>2.0.0',
+        'Flask>=2.0.0',
         'flask-restx>=0.5.1',
         'Flask-Assets>=2.0',
         'Flask-Bcrypt>=0.7.1',
@@ -24,8 +24,7 @@ setup(
         'Flask-SQLAlchemy>=2.5.1',
         'Flask-Testing>=0.8.1',
         'Flask-WTF>=0.15.1',
-        'elasticsearch>=7.0.0,<7.14.0',
-        'elasticsearch-dsl>=7.0.0,<7.4.0',
+        "elasticsearch>=7.0.0,<8.0.0",
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',
         'WTForms>=2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         # TODO: remove these pins on flask/extensions once the celery issue above is resolved
         'Flask>2.0.0,<3.0.0',
         'flask-restx>=0.5.1',
-        'Flask>=1.1.2,<2.0.0',
         'Flask-Assets>=2.0,<3.0.0',
         'Flask-Bcrypt>=0.7.1,<1.0.0',
         'Flask-Caching>=1.10.1,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',
         'WTForms>=2.0.0',
-        "aws-requests-auth==0.4.2",
+        "aws-requests-auth>=0.4.2",
         'gunicorn',
         'gevent',
         'eventlet',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Flask-Testing>=0.8.1',
         'Flask-WTF>=0.15.1',
         "elasticsearch>=7.0.0,7.14.0",
+        'elasticsearch-dsl>=7.0.0,<7.4.0',
         'shapely>=1.5.15,<1.7.0',
         'PyJWT==1.7.1',
         'WTForms>=2.0.0',


### PR DESCRIPTION
This PR updates to the latest Flask and Flask related projects. The Flask pins that limited it to a max version were removed under the `setup.py`. Due to the upgrade to the latest versions, several API calls had to be updated in the process:

- For one of the `register_blueprint` calls, a unique name was passed in as an argument. Otherwise, the following warning message occurs:
```
    /export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/scaffold.py:57:
    UserWarning: The name 'restx_doc' is already registered for this blueprint.
    Use 'name=' to provide a unique name. This will become an error in Flask 2.1.
```
- Use `get_remote_address` instead of `get_ip_addr` as this function no longer exists per https://github.com/alisaifee/flask-limiter/commit/514fe06a24b14d95e22ee47cd0f0984b6f8c8f7d#diff-ff77b4993f06d228e3e76d62903767d0d3e5e775d3399be35557c8dc856a61a6

- Use `StringField` instead of `TextField` per https://dev.to/sm0ke/cannot-import-name-textfield-from-wtforms-58n8. 

- The WTForms' validator function no longer has a `required` function. Per https://wtforms.readthedocs.io/en/3.0.x/validators/, it was recommended to use `input_required` instead.

- The importing of the `MigrateCommand` was removed as it is no longer supported per https://github.com/miguelgrinberg/Flask-Migrate/issues/407

See comments in https://hysds-core.atlassian.net/browse/HC-367 for how Pele was tested after these changes were made. A cluster was deployed with these updates. Then the Pele README was followed, where a set of Pele REST calls were made on the GRQ instance to verify that they still work.