### PR TITLE
hot-fix: Pin Werkzeug to 2.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
         'nodeenv',
         'botocore',
         'Jinja2==3.0.3',
+        'Werkzeug==2.0.3'
     ]
 )


### PR DESCRIPTION
The current HySDS Core develop is failing cluster provisioning due to the following error:

`[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m[100.104.3.102] out: ImportError: cannot import name 'safe_str_cmp' from 'werkzeug.security' `

This is due to the Werkzeug 2.1.0 release, which removed `safe_str_cmp`: https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

which impact the Flask-login module. A git issue has been filed to address this issue: https://github.com/maxcountryman/flask-login/issues/636

In case Flask-login is taking a bit to resolve, this PR will pin the Werkzeug dependency to 2.0.3 so that we can continue to develop with Core develop in our projects.

Force Branch: https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/ci-force_branch-E2E-test/19/