### PR TITLE
hot-fix: remove Jinja and Werkzeug pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,6 @@ setup(
         'webassets',
         'lxml',
         'nodeenv',
-        'botocore',
-        'Jinja2==3.0.3',
-        'Werkzeug==2.0.3'
+        'botocore'
     ]
 )


### PR DESCRIPTION
Due to the resolution of the issues to various pallet projects described in the following PRs:

- https://github.com/hysds/pele/pull/22
- https://github.com/hysds/pele/pull/23

We can safely remove the latest pins to continue pulling the latest Jinja and Werkzeug modules.

Force Branch: https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/mkarim-force_branch-E2E-test/139/
