### PR TITLE
pin werkzeug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pele',
-    version='1.1.4',
+    version='1.1.5',
     long_description='REST API for HySDS Datasets',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'webassets',
         'lxml',
         'nodeenv',
-        'botocore'
+        'botocore',
+        "werkzeug==2.1.2",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
     ]
 )


### PR DESCRIPTION
error when provisioning
```bash
Traceback (most recent call last):
  File "/export/home/hysdsops/mozart/ops/mozart/./db_create.py", line 8, in <module>
    from mozart import db
  File "/export/home/hysdsops/mozart/ops/mozart/mozart/__init__.py", line 114, in <module>
    from mozart.services.ci import services as ci_services
  File "/export/home/hysdsops/mozart/ops/mozart/mozart/services/ci.py", line 14, in <module>
    from flask_restx import Api, apidoc, Resource
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/flask_restx/__init__.py", line 5, in <module>
    from .api import Api  # noqa
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/flask_restx/api.py", line 50, in <module>
    from .swagger import Swagger
  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/flask_restx/swagger.py", line 18, in <module>
    from werkzeug.routing import parse_rule
ImportError: cannot import name 'parse_rule' from 'werkzeug.routing' (/export/home/hysdsops/mozart/lib/python3.9/site-packages/werkzeug/routing/__init__.py)
```

https://stackoverflow.com/questions/73105877/importerror-cannot-import-name-parse-rule-from-werkzeug-routing

workaround is to pin the version of werkzeug until flask-login and flaks-restx make fixes for this:
https://github.com/python-restx/flask-restx/issues/460 is open for flask-restx
https://github.com/maxcountryman/flask-login/issues/686 for flask-login.