### PR TITLE
hot-fix: Pin bcrypt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pele',
-    version='1.1.5',
+    version='1.1.6',
     long_description='REST API for HySDS Datasets',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Cython',
         # 'Cartopy==0.13.1',
         'redis',
+        'cryptography==3.4.8',
         'bcrypt',
         'coverage',
         'webassets',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         # 'Cartopy==0.13.1',
         'redis',
         'cryptography==3.4.8',
-        'bcrypt',
+        'bcrypt==3.2.2',
         'coverage',
         'webassets',
         'lxml',


### PR DESCRIPTION
This hot fix resolves an issue seen when trying to provision a cluster:

```
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    import paramiko as ssh
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/__init__.py", line 22, in <module>
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    from paramiko.transport import SecurityOptions, Transport
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/transport.py", line 91, in <module>
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    from paramiko.dsskey import DSSKey
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/dsskey.py", line 37, in <module>
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    from paramiko.pkey import PKey
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/paramiko/pkey.py", line 31, in <module>
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    import bcrypt
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m  File "/export/home/hysdsops/mozart/lib/python3.9/site-packages/bcrypt/__init__.py", line 33, in <module>
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0m    from . import _bcrypt  # noqa: I100
[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0mImportError: /usr/lib64/libc.so.6: version `GLIBC_2.28' not found (required by /export/home/hysdsops/mozart/lib/python3.9/site-packages/bcrypt/_bcrypt.abi3.so)

[0m[1mmodule.common.aws_instance.mozart (remote-exec):[0m [0mThere was a problem importing our SSH library (see traceback above).
```
Based on https://github.com/paramiko/paramiko/issues/2108#issuecomment-1251760882, the suggestion is to pin bcypt and its dependency cryptography library for now.