### PR TITLE
hot-fix: unpin cryptography module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,13 @@ setup(
         'Cython',
         # 'Cartopy==0.13.1',
         'redis',
-        'cryptography==3.4.8',
+        'cryptography',
         'bcrypt==3.2.2',
         'coverage',
         'webassets',
         'lxml',
         'nodeenv',
-        'botocore==1.29.80',
+        'botocore',
         "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'webassets',
         'lxml',
         'nodeenv',
-        'botocore',
+        'botocore==1.29.80',
         "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
     ]
 )


### PR DESCRIPTION
This hot fix resolves the following error seen when trying to provision a cluster using `hysds_release=develop`:

```
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] run: flask create-db
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out: Traceback (most recent call last):
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/bin/flask", line 8, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     sys.exit(main())
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/cli.py", line 1050, in main
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     cli.main()
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/click/core.py", line 1055, in main
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     rv = self.invoke(ctx)
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/click/core.py", line 1651, in invoke
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     cmd_name, cmd, args = self.resolve_command(ctx, args)
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/click/core.py", line 1698, in resolve_command
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     cmd = self.get_command(ctx, cmd_name)
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/cli.py", line 578, in get_command
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     app = info.load_app()
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/cli.py", line 312, in load_app
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     app = locate_app(import_name, None, raise_if_not_found=False)
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/flask/cli.py", line 218, in locate_app
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     __import__(module_name)
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/ops/pele/app.py", line 6, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from pele import create_app, db
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/ops/pele/pele/__init__.py", line 13, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from pele.lib.es_connection import get_es_client
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/ops/pele/pele/lib/es_connection.py", line 2, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/aws_requests_auth/boto_utils.py", line 7, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.session import Session
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/session.py", line 26, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     import botocore.client
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/client.py", line 15, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore import waiter, xform_name
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/waiter.py", line 18, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.docs.docstring import WaiterDocstring
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/docs/__init__.py", line 15, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.docs.service import ServiceDocumenter
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/docs/service.py", line 14, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/docs/client.py", line 17, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.docs.example import ResponseExampleDocumenter
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/docs/example.py", line 13, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.docs.shape import ShapeDocumenter
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/docs/shape.py", line 19, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from botocore.utils import is_json_value_header
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/utils.py", line 37, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     import botocore.httpsession
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/sciflo/lib/python3.9/site-packages/botocore/httpsession.py", line 46, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from urllib3.contrib.pyopenssl import (
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/conda/lib/python3.9/site-packages/urllib3/contrib/pyopenssl.py", line 50, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     import OpenSSL.crypto
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/conda/lib/python3.9/site-packages/OpenSSL/__init__.py", line 8, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from OpenSSL import SSL, crypto
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/conda/lib/python3.9/site-packages/OpenSSL/SSL.py", line 19, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     from OpenSSL.crypto import (
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:   File "/export/home/hysdsops/conda/lib/python3.9/site-packages/OpenSSL/crypto.py", line 3253, in <module>
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out:     utils.deprecated(
module.common.aws_instance.mozart (remote-exec): [100.104.3.6] out: TypeError: deprecated() got an unexpected keyword argument 'name'
```
The hot fix unpins the cryptography package, which ends up getting the latest version. During testing, this was shown to have resolved the issue:

![image](https://user-images.githubusercontent.com/42812746/222019590-0a3a1b5e-cb7b-43ca-acb6-86f94ac61c64.png)
