### PR TITLE
HC-606: Updates to support OpenSearch 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pele',
-    version='1.4.0',
+    version='1.5.0',
     long_description='REST API for HySDS Datasets',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'Flask-WTF>=0.15.1',
         "elasticsearch>=7.0.0,<7.14.0",
         'elasticsearch-dsl>=7.0.0,<7.4.0',
-        'opensearch-py>=2.3.0,<3.0.0',
+        'opensearch-py>=2.3.0',
         'shapely>=1.5.15',
         'PyJWT==1.7.1',
         'WTForms>=2.0.0',


### PR DESCRIPTION
This PR basically unpins the opensearch-py requirement such that we install the latest in order to support the migration to OpenSearch 3.x.